### PR TITLE
Issue #58 - different styles for members

### DIFF
--- a/src/web/www/javascripts/controllers/MemberController.js
+++ b/src/web/www/javascripts/controllers/MemberController.js
@@ -162,6 +162,16 @@ OKnesset.app.controllers.Member = Ext.regController('Member', {
 		var sub1 = url.substr("/member/".length);
 		return sub1.substr(0,sub1.indexOf('/'));
 	},
+    
+	getPartyIdFromAbsoluteUrl: function(url){
+		var memId = this.getIdFromAbsoluteUrl(url); 
+		var member = getMembersById(memId)[0];
+		if (typeof member ==="undefined") {
+		    return;
+		}
+		
+		return member.party_id;
+	},
 
 	refresh: function(){
 		// get current member data from Party store, which is updated

--- a/src/web/www/javascripts/controllers/PartyController.js
+++ b/src/web/www/javascripts/controllers/PartyController.js
@@ -66,6 +66,15 @@ OKnesset.app.controllers.Party = Ext.regController('Party', {
 		
 		return party.data.name;
 	},
+	isInCoalitionById : function(partyId){
+		var party = getObjectFromStoreByID(OKnesset.PartyStore, partyId);
+		if (typeof party === 'undefined') {
+			OKnesset.log("Cannot find party from id '" + partyId + "'");
+			return "";
+		}
+		
+		return party.data.is_coalition;
+	},
 
 	filterMembersByParty : function(party) {
 		OKnesset.MemberStore.clearFilter(true);

--- a/src/web/www/javascripts/controllers/PartyController.js
+++ b/src/web/www/javascripts/controllers/PartyController.js
@@ -77,7 +77,7 @@ OKnesset.app.controllers.Party = Ext.regController('Party', {
 	},
 
 	getPartyClasses : function(partyId){
-		return  "party-"+partyId + " " +this.isInCoalitionById(partyId) ? "coalition":"opposition";
+		return  "party-"+partyId + " " +(this.isInCoalitionById(partyId) ? "coalition":"opposition");
   
 	},
 

--- a/src/web/www/javascripts/controllers/PartyController.js
+++ b/src/web/www/javascripts/controllers/PartyController.js
@@ -76,6 +76,11 @@ OKnesset.app.controllers.Party = Ext.regController('Party', {
 		return party.data.is_coalition;
 	},
 
+	getPartyClasses : function(partyId){
+		return  "party-"+partyId + " " +this.isInCoalitionById(partyId) ? "coalition":"opposition";
+  
+	},
+
 	filterMembersByParty : function(party) {
 		OKnesset.MemberStore.clearFilter(true);
 		OKnesset.MemberStore.filter({

--- a/src/web/www/javascripts/views/AgendaMembersSupportListView.js
+++ b/src/web/www/javascripts/views/AgendaMembersSupportListView.js
@@ -4,16 +4,16 @@ OKnesset.app.views.AgendaMembersSupportListView = new Ext.extend(Ext.List, {
     store: OKnesset.AgendaMembersSupportListStore,
     //grouped: true,
 
-    itemTpl :  new Ext.XTemplate('<div class="memberName {[this.side(values.absolute_url)]}">{name}<div class="supportSize">{score}%</div></div>',
+    itemTpl :  new Ext.XTemplate('<div class="memberName {[this.classes(values.absolute_url)]}">{name}<div class="supportSize">{score}%</div></div>',
         {
             compiled: true,    		
-            side : function(absolute_url){
+            classes : function(absolute_url){
                 var partyId = OKnesset.app.controllers.Member.getPartyIdFromAbsoluteUrl(absolute_url);
                 
                if (typeof partyId === "undefined") {
                    return "";
                }
-                return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+               return  OKnesset.app.controllers.Party.getPartyClasses(partyId);
             }
         }
 	),

--- a/src/web/www/javascripts/views/AgendaMembersSupportListView.js
+++ b/src/web/www/javascripts/views/AgendaMembersSupportListView.js
@@ -4,7 +4,19 @@ OKnesset.app.views.AgendaMembersSupportListView = new Ext.extend(Ext.List, {
     store: OKnesset.AgendaMembersSupportListStore,
     //grouped: true,
 
-    itemTpl :'<div class="memberName">{name}<div class="supportSize">{score}%</div></div>', 
+    itemTpl :  new Ext.XTemplate('<div class="memberName {[this.side(values.absolute_url)]}">{name}<div class="supportSize">{score}%</div></div>',
+        {
+            compiled: true,    		
+            side : function(absolute_url){
+                var partyId = OKnesset.app.controllers.Member.getPartyIdFromAbsoluteUrl(absolute_url);
+                
+               if (typeof partyId === "undefined") {
+                   return "";
+               }
+                return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+            }
+        }
+	),
     onItemDisclosure: true,
   
 });

--- a/src/web/www/javascripts/views/CommitteeDetailsView.js
+++ b/src/web/www/javascripts/views/CommitteeDetailsView.js
@@ -50,16 +50,16 @@ Ext.reg('CommitteeDetailsView', OKnesset.app.views.CommitteeDetailsView);
 OKnesset.app.views.CommitteeDetailsView.committeeMembersList = new Ext.extend(Ext.List, {
     id: 'CommitteeMembersList',
     //itemTpl: '<div>{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
-    itemTpl :  new Ext.XTemplate('<div class="{[this.side(values.url)]}">{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
+    itemTpl :  new Ext.XTemplate('<div class="{[this.classes(values.url)]}">{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
         {
             compiled: true,    		
-            side : function(absolute_url){
+            classes : function(absolute_url){
                 var partyId = OKnesset.app.controllers.Member.getPartyIdFromAbsoluteUrl(absolute_url);
                 
                if (typeof partyId === "undefined") {
                    return "";
                }
-                return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+               return  OKnesset.app.controllers.Party.getPartyClasses(partyId);
             }
         }
 	),

--- a/src/web/www/javascripts/views/CommitteeDetailsView.js
+++ b/src/web/www/javascripts/views/CommitteeDetailsView.js
@@ -49,7 +49,20 @@ Ext.reg('CommitteeDetailsView', OKnesset.app.views.CommitteeDetailsView);
 
 OKnesset.app.views.CommitteeDetailsView.committeeMembersList = new Ext.extend(Ext.List, {
     id: 'CommitteeMembersList',
-    itemTpl: '<div>{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
+    //itemTpl: '<div>{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
+    itemTpl :  new Ext.XTemplate('<div class="{[this.side(values.url)]}">{name}</div><div class="Votescounters">'+ OKnesset.strings.presence +'{presence}%</div>',
+        {
+            compiled: true,    		
+            side : function(absolute_url){
+                var partyId = OKnesset.app.controllers.Member.getPartyIdFromAbsoluteUrl(absolute_url);
+                
+               if (typeof partyId === "undefined") {
+                   return "";
+               }
+                return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+            }
+        }
+	),
     store: OKnesset.CommitteeDetailsMembersListStore,
     scroll: false,
     onItemDisclosure: true,

--- a/src/web/www/javascripts/views/MemberListView.js
+++ b/src/web/www/javascripts/views/MemberListView.js
@@ -30,8 +30,8 @@ OKnesset.app.views.MemberListView.List = new Ext.extend(Ext.List, {
     		}
     	},
     	{
-			classes: true,    		
-    		side : function(partyId){
+		compiled: true,    		
+    		classes : function(partyId){
                return  OKnesset.app.controllers.Party.getPartyClasses(partyId);
     		}
     	}

--- a/src/web/www/javascripts/views/MemberListView.js
+++ b/src/web/www/javascripts/views/MemberListView.js
@@ -22,7 +22,7 @@ OKnesset.app.views.MemberListView.List = new Ext.extend(Ext.List, {
     store: OKnesset.MemberStore,
     grouped: true,
     flex: 1,
-    itemTpl: new Ext.XTemplate('<div class="{[this.side(values.party_id)]}">{name}<div class="partySize" style="font-size:80%">{[this.partyName(values.party_id)]}</div></div>', 
+    itemTpl: new Ext.XTemplate('<div class="{[this.classes(values.party_id)]}">{name}<div class="partySize" style="font-size:80%">{[this.partyName(values.party_id)]}</div></div>', 
     	{
 			compiled: true,    		
     		partyName : function(partyId){
@@ -30,9 +30,9 @@ OKnesset.app.views.MemberListView.List = new Ext.extend(Ext.List, {
     		}
     	},
     	{
-			compiled: true,    		
+			classes: true,    		
     		side : function(partyId){
-    			return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+               return  OKnesset.app.controllers.Party.getPartyClasses(partyId);
     		}
     	}
     	

--- a/src/web/www/javascripts/views/MemberListView.js
+++ b/src/web/www/javascripts/views/MemberListView.js
@@ -22,13 +22,22 @@ OKnesset.app.views.MemberListView.List = new Ext.extend(Ext.List, {
     store: OKnesset.MemberStore,
     grouped: true,
     flex: 1,
-    itemTpl: new Ext.XTemplate('<div>{name}<div class="partySize" style="font-size:80%">{[this.partyName(values.party_id)]}</div></div>', 
+    itemTpl: new Ext.XTemplate('<div class="{[this.side(values.party_id)]}">{name}<div class="partySize" style="font-size:80%">{[this.partyName(values.party_id)]}</div></div>', 
     	{
 			compiled: true,    		
     		partyName : function(partyId){
     			return OKnesset.app.controllers.Party.getNameById(partyId);
     		}
-    	}),
+    	},
+    	{
+			compiled: true,    		
+    		side : function(partyId){
+    			return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+    		}
+    	}
+    	
+    	
+    	),
     onItemDisclosure: true
 });
 

--- a/src/web/www/javascripts/views/PartyView.js
+++ b/src/web/www/javascripts/views/PartyView.js
@@ -1,3 +1,4 @@
+
 /**
  * The Member list panel (בנימין נתניהו, גדעון סער) shows a list of members
  * of the current selected party
@@ -30,7 +31,14 @@ Ext.reg('PartyView', OKnesset.app.views.PartyView);
 OKnesset.app.views.PartyView.MemberList = new Ext.extend(Ext.List, {
 	id : 'MemberList',
 	flex : 5,
-	itemTpl : '<div>{#} {name}</div>',
+	itemTpl :  new Ext.XTemplate('<div class="{[this.side(values.party_id)]}">{#} {name}</div>',    
+	    {
+			compiled: true,    		
+    		side : function(partyId){
+    			return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+    		}
+    	}
+	),
 	scroll: false,
 	store : OKnesset.MemberStore,
 	onItemDisclosure : true
@@ -50,3 +58,5 @@ OKnesset.app.views.PartyView.MiniInfo = new Ext.extend(Ext.Panel, {
 		new OKnesset.app.views.PartyView.MiniText()
 	]
 });
+
+

--- a/src/web/www/javascripts/views/PartyView.js
+++ b/src/web/www/javascripts/views/PartyView.js
@@ -31,11 +31,11 @@ Ext.reg('PartyView', OKnesset.app.views.PartyView);
 OKnesset.app.views.PartyView.MemberList = new Ext.extend(Ext.List, {
 	id : 'MemberList',
 	flex : 5,
-	itemTpl :  new Ext.XTemplate('<div class="{[this.side(values.party_id)]}">{#} {name}</div>',    
+	itemTpl :  new Ext.XTemplate('<div class="{[this.classes(values.party_id)]}">{#} {name}</div>',    
 	    {
 			compiled: true,    		
-    		side : function(partyId){
-    			return OKnesset.app.controllers.Party.isInCoalitionById(partyId) ? "coalition":"opposition";
+    		classes : function(partyId){
+               return  OKnesset.app.controllers.Party.getPartyClasses(partyId);
     		}
     	}
 	),

--- a/src/web/www/stylesheets/styles.css
+++ b/src/web/www/stylesheets/styles.css
@@ -221,3 +221,10 @@ div.subtitlePanel {
 #backBtn > img {
 	width: 23px;
 }
+
+.coalition {
+ color : green;   
+}
+.opposition {
+ color : red;   
+}


### PR DESCRIPTION
Each member now has two additional css classes: coalition\opposition and party-<party id>.

In the css file there is a different style defined for coalition\opposition members. now it is green\red - this is not a good style UX-wize, but is [useful for testing.

Waiting for icons for opposition \ coalition status so it will have a better UX
